### PR TITLE
[ADD][quality_control_tolerance] Control inspecciones en test tolerable

### DIFF
--- a/quality_control_tolerance/models/qc_inspection.py
+++ b/quality_control_tolerance/models/qc_inspection.py
@@ -17,6 +17,20 @@ class QcInspection(models.Model):
         res['max_value_above'] = line.max_value_above
         return res
 
+    @api.multi
+    def action_approve(self):
+        super(QcInspection, self).action_approve()
+        for inspection in self:
+            if inspection.state != 'failed':
+                continue
+            lines_success_tolerable = inspection.inspection_lines.filtered(
+                lambda l: l.tolerance_status in ("tolerable", "optimal"))
+            all_success_tolerable = len(lines_success_tolerable) == len(
+                inspection.inspection_lines)
+            if not all_success_tolerable:
+                continue
+            inspection.state = 'success'
+
 
 class QcInspectionLine(models.Model):
     _inherit = 'qc.inspection.line'


### PR DESCRIPTION
En caso que un test tenga el estado "tolerable" no se está aprovando el test,
ya que no se comprueba estos valores. Ahora al aprobar, si todas los tests son
"optimal" o "tolerable" se aprovará la inspección, en caso contrario como por
defecto, se marca como fallída.

TODO: Faltaría saber como rechazaro marcar una inspección como fallida en caso
que un test tolerable, no sea aprovado -> (otro botón?).